### PR TITLE
Remove a Linux test from spec.yaml for Core-Storage

### DIFF
--- a/specifications/core-storage/spec.yaml
+++ b/specifications/core-storage/spec.yaml
@@ -22,9 +22,3 @@ testCases:
       - 'should be consumable from pods in volume \[NodeConformance\]'
     skip:
       - ''
-  - description: Ability to read and write shared files on a single Kubernetes node
-      between three running Windows containers, simultaneously.
-    focus:
-      - 'should propagate mounts within defined scopes'
-    skip:
-      - ''


### PR DESCRIPTION
This removed test case is a Linux only test and does not work on Windows. 
Ref: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/mount_propagation.go#L88-L92
```
 - description: Ability to read and write shared files on a single Kubernetes node between three running Windows containers, simultaneously. 
   focus: 
      - 'should propagate mounts within defined scopes' 
   skip: 
      - ''
```
#### What type of PR is this?
Bug fix
#### What this PR does / why we need it:
This PR removes a Linux-only test case from Windows `Core-Storage` suite. The test pods are incorrectly placed on Windows node with containers specific to Linux, which causes test to always fail.

#### Which issue(s) this PR fixes: